### PR TITLE
Styles updated (Reply message's style bug)

### DIFF
--- a/generator/html/styles.css
+++ b/generator/html/styles.css
@@ -26,6 +26,7 @@ li {
   width: 100%;
   min-height: 70px;
   margin-top: 20px;
+  display: inline-block;
 }
 
 .message-body {


### PR DESCRIPTION
I fixed a bug about reply messages

When we have more than two reply messages without a normal message, reply messages move away from the right.
We need a `display: inline-block` for fix this which is in my commit.